### PR TITLE
rebuild 2.12.0 against up-to-date channel

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 3abdea97ae31bfdff5731d14c6d270d2c4171f675e2399787bb7a33b8d257595
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
The initial main build for 2.12.0 (after merging #32) failed because the conda-forge CDN repodata was stale and did not list `unicorn-binance-rest-api 2.10.0` yet (UBRA packages were uploaded at 14:34, main build tried to resolve at 15:07). Bumping build number to force a rebuild now that the channel has caught up.