### PR TITLE
update to 2.12.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unicorn-binance-websocket-api" %}
-{% set version = "2.12.0" %}
+{% set version = "2.12.2" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/unicorn_binance_websocket_api-{{ version }}.tar.gz
-  sha256: 3abdea97ae31bfdff5731d14c6d270d2c4171f675e2399787bb7a33b8d257595
+  sha256: f6cd74c671dbaac83d29d0d1024a6cbab7150c43f3f8ee898877569150b406bf
 
 build:
   number: 0


### PR DESCRIPTION
2.12.2 fixes the MANIFEST.in issue in 2.12.0/2.12.1 that caused the sdist to miss the `api/` subpackage Python sources. This is the first version that builds from sdist cleanly since the feedstock migrated to the Cython recipe.

Also requesting a rerender so the python 3.14 variants are generated (were missing from the last rerender round).

@conda-forge-admin, please rerender