### PR TITLE
v2.13.0: bump version + sha256, raise suite dep pins

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,22 +12,27 @@ jobs:
         CONFIG: osx_64_python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_python3.11.____cpython:
         CONFIG: osx_64_python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_python3.12.____cpython:
         CONFIG: osx_64_python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_python3.13.____cp313:
         CONFIG: osx_64_python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_python3.14.____cp314:
         CONFIG: osx_64_python3.14.____cp314
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,18 +11,23 @@ jobs:
       win_64_python3.10.____cpython:
         CONFIG: win_64_python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_python3.11.____cpython:
         CONFIG: win_64_python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_python3.12.____cpython:
         CONFIG: win_64_python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_python3.13.____cp313:
         CONFIG: win_64_python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_python3.14.____cp314:
         CONFIG: win_64_python3.14.____cp314
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,26 +23,31 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_python3.10.____cpython
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.11.____cpython
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.12.____cpython
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.13.____cp313
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.14.____cp314
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -119,7 +124,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unicorn-binance-websocket-api" %}
-{% set version = "2.12.2" %}
+{% set version = "2.13.0" %}
 
 
 package:
@@ -8,10 +8,10 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/unicorn_binance_websocket_api-{{ version }}.tar.gz
-  sha256: f6cd74c671dbaac83d29d0d1024a6cbab7150c43f3f8ee898877569150b406bf
+  sha256: 11715eb62574609558153271628d646180b42693050e72fbc2b4ad1545160255
 
 build:
-  number: 2
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -35,8 +35,8 @@ requirements:
     - orjson
     - psutil
     - pysocks
-    - unicorn-fy >=0.15.0
-    - unicorn-binance-rest-api >=2.7.0
+    - unicorn-fy >=0.17.2
+    - unicorn-binance-rest-api >=2.11.0
     - typing_extensions
 
 test:


### PR DESCRIPTION
### Bumps to v2.13.0

| Field | from | to |
|---|---|---|
| version | 2.12.2 | 2.13.0 |
| sha256 | f6cd74c… | 11715eb6… |
| build number | 2 | 0 |
| unicorn-fy | >=0.15.0 | >=0.17.2 |
| unicorn-binance-rest-api | >=2.7.0 | >=2.11.0 |

### Highlights of v2.13.0

USDT-M Futures (`BINANCE_FUTURES`, `BINANCE_FUTURES_TESTNET`) WebSocket streams are now routed via the per-category base paths `/public`, `/market`, `/private` introduced by Binance on 2026-04-23 — the legacy `/ws` and `/stream` paths have been decommissioned for combined streams. Channels are auto-classified at connection time and the matching path segment is prepended.

A single connection cannot mix categories anymore, so `create_stream()` now raises `ValueError` when channels/markets resolve to more than one Futures category — UBWA does not silently split a stream into multiple connections.

Spot, Margin, Isolated Margin, COIN-M, BINANCE_US, TRBINANCE and the WS-API are unaffected.

Upstream PR: oliver-zehentleitner/unicorn-binance-websocket-api#441
Issue: oliver-zehentleitner/unicorn-binance-websocket-api#437

### Checklist

- [x] Version bumped, sha256 verified against PyPI sdist
- [x] Build number reset to 0
- [x] Suite dep pins aligned with upstream `setup.py` / `pyproject.toml`
- [x] No license / source layout changes — no rerender required strictly, but happy to rerender on request